### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn install"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+[![Run on Repl.it](https://repl.it/badge/github/faizhameed/custom-hook-example)](https://repl.it/github/faizhameed/custom-hook-example)
+
 ## Custom hook example
 
 A small application showing how to write a custom hook to help us fetch data


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@faizhameed/custom-hook-example).